### PR TITLE
kafka: initial code to consume logs from kafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
+name = "cc"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colored"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +148,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +193,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+
+[[package]]
+name = "futures-task"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "futures-util"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,10 +303,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "1.1.6"
+name = "humantime"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6104619c35f8835695e517cfb80fb7142139ee4b53f4d0fa4c8dca6e98fbc66"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "integer-encoding"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
 name = "itoa"
@@ -191,6 +331,18 @@ name = "libc"
 version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -237,9 +389,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226b45a5c2ac4dd696ed30fa6b94b057ad909c7b7fc2e0d0808192bced894066"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c0fd9eba1d5db0994a239e09c1be402d35622277e35468ba891aa5e3188ce7e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "omnisci"
 version = "0.2.0"
-source = "git+https://github.com/mikehinchey/omnisci-rs#982e6a38f64cdeee55a5bb162ee8a13f8cc8e615"
+source = "git+https://github.com/mikehinchey/omnisci-rs?branch=master#982e6a38f64cdeee55a5bb162ee8a13f8cc8e615"
 dependencies = [
  "ordered-float",
  "regex",
@@ -255,12 +429,16 @@ dependencies = [
  "clap",
  "colored",
  "csv",
+ "env_logger",
  "lazy_static",
+ "log",
  "omnisci",
  "pager",
+ "rdkafka",
  "regex",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -289,6 +467,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +521,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8acd8f5c5482fdf89e8878227bafa442d8c4409f6287391c85549ca83626c27"
+dependencies = [
+ "futures",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "3.0.0+1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca35e95c88e08cdc643b25744e38ccee7c93c7e90d1ac6850fe74cbaa40803c3"
+dependencies = [
+ "cmake",
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -371,6 +618,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +638,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -439,6 +701,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+dependencies = [
+ "autocfg",
+ "num_cpus",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "try_from"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +752,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"
@@ -486,6 +786,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,21 @@ repository = "https://github.com/omnisci/log-scraper"
 [dependencies]
 chrono = "0.4"
 regex = "1"
-csv = "1"
+lazy_static = "1"
 clap = "2"
-serde_json = "1"
 pager = "0.15"
 colored = "1"
+
+csv = "1"
+serde_json = "1"
 serde = { version = "1.0", features = ["derive"] }
+
 omnisci = { git = "https://github.com/mikehinchey/omnisci-rs", branch = "master" }
-lazy_static = "1"
+
+log = "0.4"
+env_logger = "0.8"
+
+rdkafka = { version = "0.25", features = ["cmake-build"] }
+# tokio = { version = "1.0", features = ["rt", "time"], optional = true }
+# tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/Makefile
+++ b/Makefile
@@ -124,3 +124,32 @@ down:
 	docker stop ${DB_CONTAINER} || echo "container not running"
 	# docker rm -f ${DB_CONTAINER}
 .PHONY: down
+
+
+#
+# Kafka
+#
+
+k-deps:
+	# To get a kafka cluster up in docker:
+	# https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html
+	# https://github.com/confluentinc/cp-all-in-one
+
+	# Or use Redpanda instead of kafka
+	# https://vectorized.io/redpanda/
+	# https://vectorized.io/docs/quick-start-macos
+	brew install vectorizedio/tap/redpanda
+
+	# kafkacat can produce and consume text messages to kafka
+	# https://github.com/edenhill/kafkacat
+	brew install kafkacat
+
+k-up:
+	rpk container start -n 3
+	rpk topic describe omnisci_log | rpk topic create omnisci_log
+
+k-cat:
+	kafkacat -P -b localhost:9092 -t omnisci_log -l tests/gold/omnisci_server.INFO
+
+k-consume:
+	cargo run -- --brokers localhost:9092 --topics omnisci_log --groupid log-scraper-test1

--- a/filebeat/docker-compose.yml
+++ b/filebeat/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  filebeat:
+    container_name: filebeat
+    image: 'docker.elastic.co/beats/filebeat:7.10.2'
+    volumes:
+      - ./filebeat.yml:/usr/share/filebeat/filebeat.yml
+      - ${PWD}/../target/omnisci-test-db/data/mapd_log:/data/mapd_log

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -1,0 +1,19 @@
+output.kafka:
+  hosts: ["localhost:9092"]
+  version: "2.0.0"
+  topic: "omnisci_log"
+  ssl:
+    enabled: false
+  require_acks: 1
+
+filebeat.inputs:
+- type: log
+  enabled: true
+  paths:
+    - /data/mapd_log/omnisci_server.INFO.*
+  symlink: true
+  fields:
+    hostname: 'testhost'
+
+#logging:
+#  level: debug

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2021 OmniSci, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use log::{warn, debug};
+
+use rdkafka::client::ClientContext;
+use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
+use rdkafka::consumer::stream_consumer::StreamConsumer;
+use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance};
+use rdkafka::error::KafkaResult;
+use rdkafka::message::{Message}; // Headers
+use rdkafka::topic_partition_list::TopicPartitionList;
+// use rdkafka::util::get_rdkafka_version;
+
+use crate::log_parser::{LogLine, LogWriter, new_log_writer, SResult, OutputType};
+
+struct CustomContext;
+
+impl ClientContext for CustomContext {}
+
+impl ConsumerContext for CustomContext {
+    fn pre_rebalance(&self, rebalance: &Rebalance) {
+        debug!("pre_rebalance {:?}", rebalance);
+    }
+
+    fn post_rebalance(&self, rebalance: &Rebalance) {
+        debug!("post_rebalance {:?}", rebalance);
+    }
+
+    fn commit_callback(&self, _result: KafkaResult<()>, _offsets: &TopicPartitionList) {
+        // debug!("commit_callback: {:?}", result);
+    }
+}
+
+type LogConsumer = StreamConsumer<CustomContext>;
+
+pub enum InputFormat {
+    Guess,
+    Line,
+    FilebeatJson,
+}
+
+async fn consume_logs(consumer: &LogConsumer, writer: &mut Box<dyn LogWriter>, hostname: Option<&str>) {
+    let mut input_format = InputFormat::Guess;
+
+    let mut hostname = match hostname{
+        None => None,
+        Some(hostname) => Some(hostname.to_string()),
+    };
+
+    let mut prev: Option<LogLine> = None;
+
+    loop {
+        match consumer.recv().await {
+            Err(e) => warn!("Kafka error: {}", e),
+            Ok(m) => {
+                let payload = match m.payload_view::<str>() {
+                    None => continue,
+                    Some(Ok(s)) => s,
+                    Some(Err(e)) => {
+                        warn!("Error while deserializing message payload: {:?}", e);
+                        continue
+                    }
+                };
+                // info!("key: '{:?}', payload: '{}', topic: {}, partition: {}, offset: {}, timestamp: {:?}",
+                //       m.key(), payload, m.topic(), m.partition(), m.offset(), m.timestamp());
+                // if let Some(headers) = m.headers() {
+                //     for i in 0..headers.count() {
+                //         let header = headers.get(i).unwrap();
+                //         info!("  Header {:#?}: {:?}", header.0, header.1);
+                //     }
+                // }
+
+                if let InputFormat::Guess = &input_format {
+                    if payload.starts_with("{") {
+                        input_format = InputFormat::FilebeatJson;
+                    }
+                    else {
+                        input_format = InputFormat::Line;
+                    }
+                }
+
+                let mut message_string = String::new();
+                let message = match &input_format {
+                    InputFormat::Guess => payload,
+                    InputFormat::Line => payload,
+                    InputFormat::FilebeatJson => {
+                        match serde_json::from_str::<serde_json::Value>(payload) {
+                            Ok(v) => {
+                                if v.is_object() {
+                                    if let Some(fields) = v.get("fields") {
+                                        hostname = Some(fields["hostname"].to_string());
+                                    }
+                                    // TODO this is ugly, but is there a better way to get a &str?
+                                    message_string.push_str(v["message"].as_str().unwrap());
+                                    message_string.as_str()
+                                }
+                                else {
+                                    payload
+                                }
+                            },
+                            Err(_) => payload,
+                        }
+                    },
+                };
+
+                match LogLine::new(&message) {
+                    Err(_) => {
+                        match &prev {
+                            None => {
+                                warn!("Unexpected, unable to parse message: {:?}", m);
+                                consumer.commit_message(&m, CommitMode::Async).unwrap();
+                            },
+                            Some(prev_x) => {
+                                // TODO Is there a better way to append_msg without cloning that is allowed by the borrow checker?
+                                let mut tmp = prev_x.clone();
+                                tmp.append_msg(payload);
+                                prev = Some(tmp);
+                            },
+                        }
+                    },
+                    Ok(curr) => {
+                        match &prev {
+                            None => {
+                                prev = Some(curr);
+                            },
+                            Some(prev_x) => {
+                                let mut tmp = prev_x.clone();
+                                tmp.parse_msg();
+                                tmp.hostname = hostname.clone();
+                                match writer.write(&tmp) {
+                                    Err(e) => warn!("Error writing {:?}", e),
+                                    Ok(_) => {
+                                        consumer.commit_message(&m, CommitMode::Async).unwrap()
+                                    },
+                                };
+
+                                prev = Some(curr);
+                            },
+                        }
+                    },
+                }
+            }
+        };
+    }
+}
+
+pub async fn consume_logs_main(brokers: &str, group_id: &str, topics: &[&str],
+    output: Option<&str>, output_type: &OutputType, db: Option<&str>, hostname: Option<&str>)
+-> SResult<()> {
+    let context = CustomContext;
+
+    // https://docs.rs/rdkafka/0.25.0/rdkafka/
+    // https://github.com/edenhill/librdkafka/wiki
+    // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+    let consumer: LogConsumer = ClientConfig::new()
+        .set("group.id", group_id)
+        .set("bootstrap.servers", brokers)
+        .set("enable.partition.eof", "false")
+        .set("session.timeout.ms", "6000")
+        .set("enable.auto.commit", "true")
+        //.set("statistics.interval.ms", "30000")
+        .set("auto.offset.reset", "smallest")
+        .set_log_level(RDKafkaLogLevel::Debug)
+        .create_with_context(context)
+        .expect("Consumer creation failed");
+
+    consumer
+        .subscribe(&topics.to_vec())
+        .expect("Can't subscribe to specified topics");
+
+    // let filter: Vec<&str> = vec!();
+    let mut writer = new_log_writer(None, &vec!(), output, &output_type, db)?;
+
+    consume_logs(&consumer, &mut writer, hostname).await;
+
+    writer.close()
+}

--- a/src/log_parser/lineparser.rs
+++ b/src/log_parser/lineparser.rs
@@ -884,7 +884,7 @@ impl OutputType {
     }
 }
 
-trait LogWriter {
+pub trait LogWriter {
     fn write(&mut self, log: &LogLine) -> SResult<()>;
     fn close(&mut self) -> SResult<()> { Ok(()) }
 }
@@ -1176,12 +1176,12 @@ fn output_filename(input: &str, output: &str, extension: &str) -> String {
     }
 }
 
-fn new_log_writer(input: &str, filter: &Vec<&str>, output: Option<&str>, output_type: &OutputType, db: Option<&str>) -> SResult<Box<dyn LogWriter>> {
+pub fn new_log_writer(input: Option<&str>, filter: &Vec<&str>, output: Option<&str>, output_type: &OutputType, db: Option<&str>) -> SResult<Box<dyn LogWriter>> {
     match output {
         Some(path) => match output_type {
             OutputType::Terminal => Ok(Box::new(TerminalWriter::new())),
             OutputType::CSV => {
-                let x = csv::Writer::from_path(output_filename(input, path, "csv"))?;
+                let x = csv::Writer::from_path(output_filename(input.unwrap(), path, "csv"))?;
                 if filter.contains(&"sql") {
                     // TODO write only sql fields
                     Ok(Box::new(CsvFileLogWriter{ writer: x}))
@@ -1234,7 +1234,7 @@ pub fn transform_logs(
     let file = fs::File::open(Path::new(input))?;
     let mut reader = BufReader::new(file);
 
-    let mut writer = new_log_writer(input, filter, output, &output_type, db)?;
+    let mut writer = new_log_writer(Some(input), filter, output, &output_type, db)?;
     let hostname: Option<String> = match hostname {
         None => None,
         Some(x) => Some(x.to_string())


### PR DESCRIPTION
Supports either plain text lines
or json in the filebeat structure plus a hostname field.

Not fully working yet, needs more around
handling multi-line, and better control of the tokio async.